### PR TITLE
Automatic granularity - avoids manual cdo resampling.

### DIFF
--- a/src/spinup_evaluation/xgran/analysis.py
+++ b/src/spinup_evaluation/xgran/analysis.py
@@ -1,0 +1,289 @@
+"""
+Perform resampling analysis prior to data processing.
+
+This module contains all the analysis functions for determining what variables
+and metrics can run at different temporal granularities in climate data processing.
+
+Functions:
+- analyze_variable_availability: Core function to analyze variable availability
+- analyze_metric_requirements: Analyze what metrics can run at what granularities
+- get_runnable_metrics_at_granularity: Get metrics that can run at specific granularity
+- get_optimal_granularities_for_metrics: Find finest granularity for each metric
+- show_availability_summary: Comprehensive availability report
+- get_maximum_granularity_with_all: Find granularity where most metrics can run
+"""
+
+import os
+
+GRANULARITY_ORDER = ["10d", "1m", "3m", "1y"]
+
+
+def get_available_granularities(variable_file_map):
+    """Get all available granularities from the file map."""
+    all_grans = set()
+    for name, entries in variable_file_map.items():
+        for entry in entries:
+            # breakpoint()
+            if name == "mesh_mask":
+                continue
+            all_grans.add(entry["granularity"])
+    return sorted(all_grans, key=GRANULARITY_ORDER.index)
+
+
+def analyse_variable_availability(variable_file_map, required_vars=None):
+    """
+    Core function: analyze what variables are available at what granularities.
+
+    Handles both direct files and resampling possibilities
+
+    Args:
+        variable_file_map: Dictionary mapping variables to file entries
+        required_vars: List of variables to analyze (if None, analyzes all)
+
+    Returns
+    -------
+        Dictionary containing:
+        - variable_availability: Dict of var -> list of achievable granularities
+        - available_granularities: List of all granularities in the system
+        - direct_files: Dict of var -> list of granularities with direct files
+    """
+    available_grans = get_available_granularities(variable_file_map)
+
+    # If no specific variables requested, analyze all
+    if required_vars is None:
+        all_vars = set()
+        for _ in variable_file_map.values():
+            all_vars.update(variable_file_map.keys())
+        required_vars = all_vars
+
+    variable_availability = {}
+    direct_files = {}
+
+    for var in required_vars:
+        variable_availability[var] = []
+
+        # Check direct file availability
+        direct_available = []
+        for entry in variable_file_map.get(var, []):
+            if os.path.exists(entry["file"]):
+                direct_available.append(entry["granularity"])
+
+        direct_files[var] = direct_available
+        print(f"{var}: direct files at {direct_available}")
+
+        # For each target granularity, check if achievable
+        for target_gran in available_grans:
+            # Direct file available?
+            if target_gran in direct_available:
+                variable_availability[var].append(target_gran)
+                print(f"{var}: achievable at {target_gran} (direct)")
+                continue
+
+            # Can we resample from a finer granularity?
+            target_rank = GRANULARITY_ORDER.index(target_gran)
+            can_resample = any(
+                GRANULARITY_ORDER.index(direct_gran) < target_rank
+                for direct_gran in direct_available
+            )
+
+            if can_resample:
+                variable_availability[var].append(target_gran)
+                print(f"{var}: achievable at {target_gran} (via resampling)")
+            else:
+                print(f"{var}: NOT achievable at {target_gran}")
+
+    return {
+        "variable_availability": variable_availability,
+        "available_granularities": available_grans,
+        "direct_files": direct_files,
+    }
+
+
+def analyze_metric_requirements(variable_file_map, metric_requirements):
+    """
+    Analyze what metrics can run at what granularities.
+
+    Built on top of analyze_variable_availability
+
+    Args:
+        variable_file_map: Dictionary mapping variables to file entries
+        metric_requirements: Dictionary mapping metric names to required variables
+
+    Returns
+    -------
+        Dictionary containing all variable availability info plus:
+        - runnable_metrics: Dict of granularity -> list of runnable metric names
+    """
+    # Get all variables needed by metrics
+    all_vars = set()
+    for vars_list in metric_requirements.values():
+        all_vars.update(vars_list)
+
+    # Analyze variable availability
+    analysis = analyse_variable_availability(variable_file_map, all_vars)
+
+    # Determine runnable metrics per granularity
+    runnable_metrics = {}
+    for gran in analysis["available_granularities"]:
+        runnable_metrics[gran] = []
+
+        for metric_name, required_vars in metric_requirements.items():
+            if all(
+                gran in analysis["variable_availability"].get(var, [])
+                for var in required_vars
+            ):
+                runnable_metrics[gran].append(metric_name)
+
+    # Add metrics analysis to the result
+    analysis["runnable_metrics"] = runnable_metrics
+
+    # Build a mapping: granularity -> list of variables available at that granularity
+    granularity_to_variables = {
+        gran: [] for gran in analysis["available_granularities"]
+    }
+    for var, grans in analysis["variable_availability"].items():
+        for gran in grans:
+            granularity_to_variables[gran].append(var)
+
+    analysis["granularity_to_variables"] = granularity_to_variables
+
+    # invert the direct files so we index by granularity and return the
+    # available variables
+    direct_from_file_by_granularity = {
+        gran: [] for gran in analysis["available_granularities"]
+    }
+    for var, direct_grans in analysis["direct_files"].items():
+        for gran in direct_grans:
+            direct_from_file_by_granularity[gran].append(var)
+
+    analysis["direct_from_file_by_granularity"] = direct_from_file_by_granularity
+
+    return analysis
+
+
+def get_runnable_metrics_at_granularity(
+    variable_file_map, metric_requirements, target_granularity
+):
+    """
+    Get what metrics can run at a specific granularity.
+
+    Args:
+        variable_file_map: Dictionary mapping variables to file entries
+        metric_requirements: Dictionary mapping metric names to required variables
+        target_granularity: Granularity to check (e.g., "1m", "3m")
+
+    Returns
+    -------
+        List of metric names that can run at the target granularity
+    """
+    analysis = analyze_metric_requirements(variable_file_map, metric_requirements)
+    return analysis["runnable_metrics"].get(target_granularity, [])
+
+
+# Find the maximum granularity where each metric can be computed
+def get_optimal_granularities_for_metrics(variable_file_map, metric_requirements):
+    """
+    Get the finest granularity where each metric can run.
+
+    Args:
+        variable_file_map: Dictionary mapping variables to file entries
+        metric_requirements: Dictionary mapping metric names to required variables
+
+    Returns
+    -------
+        Dictionary mapping metric names to their finest achievable granularity
+    """
+    analysis = analyze_metric_requirements(variable_file_map, metric_requirements)
+
+    optimal_grans = {}
+    for metric_name in metric_requirements:
+        # Find finest granularity where this metric can run
+        for gran in GRANULARITY_ORDER:  # Finest to coarsest
+            if metric_name in analysis["runnable_metrics"].get(gran, []):
+                optimal_grans[metric_name] = gran
+                break
+
+    return optimal_grans
+
+
+# Find the maximum granularity where all metrics can be computed
+def get_maximum_granularity_with_all(
+    variable_file_map, metric_requirements, GRANULARITY_ORDER=None
+):
+    """
+    Find the granularity where the most metrics can run.
+
+    Args:
+        variable_file_map: Dictionary mapping variables to file entries
+        metric_requirements: Dictionary mapping metric names to required variables
+        GRANULARITY_ORDER: Optional custom granularity order
+
+    Returns
+    -------
+        String representing the best granularity for running the most metrics
+    """
+    if GRANULARITY_ORDER is None:
+        GRANULARITY_ORDER = ["10d", "1m", "3m", "1y"]
+
+    analysis = analyze_metric_requirements(variable_file_map, metric_requirements)
+
+    # Find granularity with most runnable metrics
+    best_gran = None
+    max_metrics = 0
+
+    for gran, metrics in analysis["runnable_metrics"].items():
+        if len(metrics) > max_metrics:
+            max_metrics = len(metrics)
+            best_gran = gran
+
+    print(
+        (
+            f"\nBest granularity: {best_gran} "
+            f"(can run {max_metrics} metrics: "
+            f"{analysis['runnable_metrics'][best_gran]})"
+        )
+    )
+    return best_gran
+
+
+def show_availability_summary(variable_file_map, metric_requirements):
+    """
+    Comprehensive summary of what's possible.
+
+    Args:
+        variable_file_map: Dictionary mapping variables to file entries
+        metric_requirements: Dictionary mapping metric names to required variables
+
+    Returns
+    -------
+        Full analysis dictionary for further processing
+    """
+    analysis = analyze_metric_requirements(variable_file_map, metric_requirements)
+
+    print("\n=== AVAILABILITY SUMMARY ===")
+
+    # Variable availability
+    print("\nVariable availability:")
+    for var, grans in analysis["variable_availability"].items():
+        direct = analysis["direct_files"][var]
+        resampled = [g for g in grans if g not in direct]
+        print(f"  {var}:")
+        print(f"    Direct: {direct}")
+        if resampled:
+            print(f"    Resampled: {resampled}")
+
+    # Metric possibilities
+    print("\nMetric possibilities:")
+    for gran, metrics in analysis["runnable_metrics"].items():
+        if metrics:
+            print(f"  At {gran}: {metrics}")
+
+    # Optimal granularities
+    optimal = get_optimal_granularities_for_metrics(
+        variable_file_map, metric_requirements
+    )
+    print("\nOptimal granularities (finest possible):")
+    for metric, gran in optimal.items():
+        print(f"  {metric}: {gran}")
+
+    return analysis

--- a/src/spinup_evaluation/xgran/cache.py
+++ b/src/spinup_evaluation/xgran/cache.py
@@ -1,0 +1,196 @@
+"""Cache utilities for resampled and aligned xarray data.
+
+This module provides functions to save, load, and manage cached
+resampled and time-aligned xarray DataArrays, including metadata
+handling and cache statistics.
+"""
+
+import glob
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+import xarray as xr
+
+from .fix_time import ensure_time
+
+
+# USED (1) - called from get_data
+def save_resampled_to_disk(
+    data, var, source_gran, target_gran, source_file, cache_dir="./resampled_cache"
+):
+    """Save resampled data to cache."""
+    os.makedirs(cache_dir, exist_ok=True)
+
+    cache_file = get_cache_filename(var, source_gran, target_gran, cache_dir)
+    metadata_file = cache_file.replace(".nc", "_metadata.json")
+
+    try:
+        # Save data
+        print(f"Caching {var} {source_gran}→{target_gran} to {cache_file}")
+        data.to_netcdf(cache_file)
+
+        # Save metadata
+        metadata = {
+            "variable": var,
+            "source_granularity": source_gran,
+            "target_granularity": target_gran,
+            "source_file": source_file,
+            "source_hash": get_file_hash(source_file),
+            "created": pd.Timestamp.now().isoformat(),
+            "shape": list(data.shape),
+            "chunks": str(data.chunks) if hasattr(data, "chunks") else None,
+        }
+
+        with open(metadata_file, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        print(f"✓ Cached {var} {source_gran}→{target_gran}")
+
+    except (OSError, TypeError) as e:
+        print(f"Cache save failed: {e}")
+
+
+# USED (1) - called from get_data
+def load_resampled_from_disk(
+    var, source_gran, target_gran, source_file, cache_dir="./resampled_cache"
+):
+    """Load resampled data from cache if available and valid."""
+    cache_file = get_cache_filename(var, source_gran, target_gran, cache_dir)
+    metadata_file = cache_file.replace(".nc", "_metadata.json")
+
+    if not (os.path.exists(cache_file) and os.path.exists(metadata_file)):
+        return None
+
+    # Check if source file has changed
+    try:
+        with open(metadata_file, "r") as f:
+            metadata = json.load(f)
+
+        current_hash = get_file_hash(source_file)
+        if metadata.get("source_hash") != current_hash:
+            print(
+                (
+                    f"Source file changed, cache invalid for {var} "
+                    f"{source_gran}→{target_gran}"
+                )
+            )
+            return None
+
+        print(f"Loading {var} {source_gran}→{target_gran} from cache")
+        return xr.open_dataarray(cache_file, chunks={"time": 100})
+
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Cache load failed: {e}")
+        return None
+
+
+# USED (1)
+def save_aligned_to_disk(
+    data: xr.DataArray,
+    var: str,
+    target_gran: str,
+    ref_var: str,
+    cache_dir: str = "./resampled_cache",
+) -> str:
+    """Save time-aligned data to cache."""
+    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    th = _time_hash(data)
+    fname = f"{var}_ALIGNED_to_{target_gran}_{th}.nc"
+    fpath = os.path.join(cache_dir, fname)
+    ensure_time(data).to_netcdf(fpath)
+
+    meta = {
+        "variable": var,
+        "target_granularity": target_gran,
+        "aligned": True,
+        "reference_variable": ref_var,
+        "time_hash": th,
+        "calendar": ensure_time(data)["time"].attrs.get("calendar"),
+        "units": ensure_time(data)["time"].attrs.get("units"),
+    }
+    with open(fpath.replace(".nc", "_metadata.json"), "w") as f:
+        json.dump(meta, f, indent=2)
+    return fpath
+
+
+# USED (1) (mainly) and (2) - need to check how this affects (2)
+def load_aligned_from_disk(var, target_gran, cache_dir="./resampled_cache"):
+    """Load aligned data from cache if available."""
+    pattern = os.path.join(cache_dir, f"{var}_ALIGNED_to_{target_gran}_*.nc")
+    hits = sorted(glob.glob(pattern))
+    if hits:
+        print(f"Loading {var} ALIGNED→{target_gran} from cache")
+        return xr.open_dataarray(hits[-1], chunks={"time": 100})
+    return None
+
+
+# USED (1)
+def _time_hash(da: xr.DataArray) -> str:
+    t = ensure_time(da)["time"].values
+    return hashlib.sha1("".join(map(str, t)).encode()).hexdigest()[:16]  # noqa 5324
+
+
+def get_cache_filename(var, source_gran, target_gran, cache_dir="./resampled_cache"):
+    """Generate consistent cache filename."""
+    cache_key = f"{var}_{source_gran}_to_{target_gran}"
+    return os.path.join(cache_dir, f"{cache_key}.nc")
+
+
+def get_file_hash(filepath):
+    """Get hash of source file to detect changes."""
+    with open(filepath, "rb") as f:
+        # Hash first 1MB for speed
+        return hashlib.md5(f.read(1024 * 1024)).hexdigest()  # noqa 5324
+
+
+def write_metadata(cache_file, meta: dict):
+    """Write metadata for cached file."""
+    meta_file = cache_file.replace(".nc", "_metadata.json")
+    with open(meta_file, "w") as f:
+        json.dump(meta, f, indent=2)
+
+
+def show_cache_stats(cache_dir="./resampled_cache"):
+    """Show cache statistics."""
+    if not os.path.exists(cache_dir):
+        print("No disk cache found")
+        return
+
+    nc_files = [f for f in os.listdir(cache_dir) if f.endswith(".nc")]
+    if not nc_files:
+        print("Cache directory exists but is empty")
+        return
+
+    total_size = 0
+    cached_items = []
+
+    for nc_file in nc_files:
+        file_path = os.path.join(cache_dir, nc_file)
+        size = os.path.getsize(file_path)
+        total_size += size
+
+        # Parse filename: "temperature_10d_to_1m.nc"
+        name_parts = nc_file[:-3].split("_to_")
+        PARTS = 2
+        if len(name_parts) == PARTS:
+            source_parts = name_parts[0].split("_")
+            if len(source_parts) >= PARTS:
+                var = "_".join(source_parts[:-1])
+                source_gran = source_parts[-1]
+                target_gran = name_parts[1]
+                cached_items.append((var, source_gran, target_gran, size))
+
+    print("\n=== DISK CACHE STATISTICS ===")
+    print(f"Cache directory: {cache_dir}")
+    print(f"Total files: {len(nc_files)}")
+    print(f"Total size: {total_size / 1024**3:.2f} GB")
+
+    if cached_items:
+        print("\nCached resampled data:")
+        for var, source_gran, target_gran, size in sorted(cached_items):
+            print(f"  {var}: {source_gran}→{target_gran} ({size / 1024**2:.1f} MB)")
+    else:
+        print("No valid cached items found")

--- a/src/spinup_evaluation/xgran/compute.py
+++ b/src/spinup_evaluation/xgran/compute.py
@@ -1,0 +1,295 @@
+"""Compute module for spinup evaluation.
+
+This module provides functions for retrieving, resampling, aligning, and caching
+xarray-based variable data at various temporal granularities for metric analysis.
+"""
+
+import xarray as xr
+
+from spinup_evaluation.standardise_inputs import VARIABLE_ALIASES, standardise
+
+from .cache import (
+    load_aligned_from_disk,
+    load_resampled_from_disk,
+    save_aligned_to_disk,
+    save_resampled_to_disk,
+)
+from .fix_time import ensure_time, find_time_dimension, resample_like, same_time_axis
+
+GRANULARITY_ORDER = ["10d", "1m", "3m", "1y"]
+
+
+# USED (1) and (2) public interface
+def get_data(
+    var,
+    granularity,
+    variable_file_map,
+    cache,
+    analysis,
+    allow_resampling=True,
+    disk_cache_dir="./resampled_cache",
+    save_to_cache=True,
+):
+    """
+    Retrieve data for a variable at a given granularity.
+
+    We are using memory and disk cache, and resampling from the closest
+    available finer granularity if needed.
+    """
+    key = (var, granularity)
+    if key in cache:
+        print("MEMORY CACHE HIT", key)
+        return cache[key]
+
+    # aligned artifact takes precedence (skips re-binning later)
+    aligned = load_aligned_from_disk(var, granularity, disk_cache_dir)
+    if aligned is not None:
+        cache[key] = aligned
+        return aligned
+
+    # 1. Try direct file first
+    if granularity in analysis["direct_files"].get(var, []):
+        file_entry = next(
+            e for e in variable_file_map[var] if e["granularity"] == granularity
+        )
+        print(f"Loading {var}@{granularity} directly from {file_entry['file']}")
+        ds = xr.open_dataset(file_entry["file"])
+        ds = standardise(ds, VARIABLE_ALIASES)
+        if var in ds:
+            data = ds[var]
+            cache[key] = data
+            return data
+        else:
+            msg = f"Variable {var} not found in {file_entry['file']}"
+            raise ValueError(msg)
+
+    # 2. Otherwise, resample from closest available finer granularity
+    if allow_resampling:
+        gran_idx = GRANULARITY_ORDER.index(granularity)
+        finer_grans = [
+            g
+            for g in analysis["direct_files"].get(var, [])
+            if GRANULARITY_ORDER.index(g) < gran_idx
+        ]
+        if not finer_grans:
+            msg = (
+                f"No finer granularity available for {var} to resample to {granularity}"
+            )
+            raise ValueError(msg)
+
+        # NOTE: Pick the closest (highest index < gran_idx).
+        # Prefer to get finest for accuracy
+        # source_gran = max(finer_grans, key=lambda g: GRANULARITY_ORDER.index(g))
+
+        # Pick the finest granularity
+        source_gran = min(finer_grans, key=lambda g: GRANULARITY_ORDER.index(g))
+        source_file = next(
+            e["file"] for e in variable_file_map[var] if e["granularity"] == source_gran
+        )
+
+        # Try disk cache for resampled data
+        cached_resampled = load_resampled_from_disk(
+            var, source_gran, granularity, source_file, disk_cache_dir
+        )
+        if cached_resampled is not None:
+            cache[key] = cached_resampled
+            return cached_resampled
+
+        print(f"Resampling {var}: {source_gran} → {granularity}")
+
+        # Get source data (recursive call)
+        finer_data = get_data(
+            var,
+            source_gran,
+            variable_file_map,
+            cache,
+            analysis,
+            allow_resampling,
+            disk_cache_dir,
+            save_to_cache,
+        )
+
+        # Resample
+        time_dim = find_time_dimension(finer_data)
+        if time_dim is None:
+            msg = f"No time dimension found in {var}. Dims: {finer_data.dims}"
+            raise ValueError(msg)
+
+        # Use fallback_freq for resampling frequency string
+        freq_map = {"10d": "10D", "1m": "1ME", "3m": "3ME", "1y": "1YE"}
+        resample_kwargs = {time_dim: freq_map[granularity]}
+        resampled = finer_data.resample(
+            **resample_kwargs, label="right", closed="right"
+        ).mean(skipna=True)
+
+        # Optionally save to disk cache
+        if save_to_cache:
+            save_resampled_to_disk(
+                resampled.compute(),
+                var,
+                source_gran,
+                granularity,
+                source_file,
+                disk_cache_dir,
+            )
+            # Reload as lazy for memory efficiency
+            cached_data = load_resampled_from_disk(
+                var, source_gran, granularity, source_file, disk_cache_dir
+            )
+            cache[key] = cached_data
+            return cached_data
+        else:
+            print("  Not saving to cache (save_to_cache=False)")
+            cache[key] = resampled  # Keep as lazy
+            return resampled
+
+    msg = f"{var} not available at {granularity} and resampling not allowed"
+    raise ValueError(msg)
+
+
+# Maybe USED (1) - called from run_all_metrics_with_cache and
+# run_metrics_intelligently_with_cache
+# NOTE: This doesn't do alignment - so it will fail.
+def run_metric_with_cache(
+    metric_name,
+    metric_function,
+    required_vars,
+    granularity,
+    variable_file_map,
+    analysis,
+    cache=None,
+    down_sample=True,
+    disk_cache_dir="./resampled_cache",
+    save_to_cache=True,
+):
+    """Run_metric with disk caching."""
+    try:
+        print(f"Running {metric_name} at {granularity}")
+        inputs = [
+            get_data(
+                var,
+                granularity,
+                variable_file_map,
+                cache,
+                analysis,
+                down_sample,
+                disk_cache_dir,
+                save_to_cache,
+            )
+            for var in required_vars
+        ]
+        result = metric_function(*inputs)
+        print(f"✓ Success: {metric_name}")
+        return result
+    except (KeyError, ValueError, OSError) as e:
+        print(f"✗ Failed: {metric_name} - {e}")
+        return None
+
+
+# USED (1) - called from preload_and_align_all_variables
+def load_all_variables_at_granularity(
+    gran, variable_file_map, analysis, cache, disk_cache_dir, save_to_cache
+):
+    """
+    Load all variables available at a given granularity (direct or resampled).
+
+    Returns a dict: {var: xarray.DataArray}
+    """
+    available_vars = [
+        var for var, grans in analysis["variable_availability"].items() if gran in grans
+    ]
+    loaded_vars = {}
+    for var in available_vars:
+        try:
+            data = get_data(
+                var,
+                gran,
+                variable_file_map,
+                cache,
+                analysis=analysis,
+                allow_resampling=True,
+                disk_cache_dir=disk_cache_dir,
+                save_to_cache=save_to_cache,
+            )
+            loaded_vars[var] = data
+        except (KeyError, ValueError, OSError) as e:
+            print(f"✗ Failed to load {var}@{gran}: {e}")
+    return loaded_vars
+
+
+# USED (1) - called from preload_and_align_all_variables
+def align_all_to_reference(
+    loaded_vars: dict[str, xr.DataArray],
+    ref_var: str,
+    fallback_freq: str | None = None,
+) -> dict[str, xr.DataArray]:
+    """
+    For each variable, return a version whose time axis exactly matches reference.
+
+    Only resamples when needed; otherwise returns the data unchanged.
+    """
+    ref = ensure_time(loaded_vars[ref_var])
+    aligned = {}
+    for name, da in loaded_vars.items():
+        da_ensured = ensure_time(da)
+        if same_time_axis(da_ensured, ref):
+            aligned[name] = da_ensured
+        else:
+            aligned[name] = resample_like(da_ensured, ref, fallback_freq=fallback_freq)
+    return aligned
+
+
+# USED (1) - public interface
+def preload_and_align_all_variables(
+    variable_file_map,
+    granularities,
+    analysis,
+    disk_cache_dir="./resampled_cache",
+    save_to_cache=False,
+    persist_aligned=False,
+):
+    """Preload and align all variables to a common reference."""
+    cache = {}
+    aligned_vars_by_gran = {}
+
+    for gran in granularities:
+        print(f"\n=== GRANULARITY: {gran} ===")
+        loaded_vars = load_all_variables_at_granularity(
+            gran, variable_file_map, analysis, cache, disk_cache_dir, save_to_cache
+        )
+
+        direct_vars = analysis["direct_from_file_by_granularity"].get(gran, [])
+        ref_var = next((var for var in direct_vars if var in loaded_vars), None)
+        if ref_var is None:
+            print(f"No reference variable for {gran}")
+            aligned_vars_by_gran[gran] = loaded_vars
+            continue
+        print(f"Using '{ref_var}' as reference for alignment at {gran}")
+
+        # Get calendar and units from the reference variable's time coordinate
+        # ref_data = loaded_vars[ref_var]
+        # time_dim = find_time_dimension(ref_data)
+        # calendar = ref_data[time_dim].attrs.get("calendar", "360_day")
+        # units = ref_data[time_dim].attrs.get("units", "days since 0001-01-01")
+
+        # Align all variables to the reference bins
+        # aligned_vars = align_all_variables_to_reference_bins(
+        #     loaded_vars, ref_var, calendar, units, time_dim=time_dim,
+        #     fallback_freq=gran
+        # )
+
+        # NOTE: There's enough information in loaded vars
+        # or in aligned_vars or even cache at this given granularity
+        # to get the granularity of the data he target was sampled from.
+        aligned_vars = align_all_to_reference(loaded_vars, ref_var, fallback_freq=gran)
+
+        # Optional saving of aligned files to disk
+        # Note that these are different to
+        if persist_aligned:
+            for var, da in aligned_vars.items():
+                save_aligned_to_disk(da, var, gran, ref_var, cache_dir=disk_cache_dir)
+
+        for var, data in aligned_vars.items():
+            cache[(var, gran)] = data
+
+    return cache

--- a/src/spinup_evaluation/xgran/fix_time.py
+++ b/src/spinup_evaluation/xgran/fix_time.py
@@ -1,0 +1,151 @@
+"""Utility functions for handling and aligning time dimensions in xarray DataArrays."""
+
+import cftime
+import numpy as np
+import xarray as xr
+
+
+def ensure_time(da: xr.DataArray) -> xr.DataArray:
+    """Ensure the DataArray has a 'time' dimension, renaming if needed."""
+    for cand in ("time", "time_counter", "t", "T", "Time"):
+        if cand in da.dims:
+            return da if cand == "time" else da.rename({cand: "time"})
+    for d in da.dims:
+        if "time" in d.lower():
+            return da.rename({d: "time"})
+    msg = "No time-like dimension found"
+    raise ValueError(msg)
+
+
+def same_time_axis(a: xr.DataArray, b: xr.DataArray) -> bool:
+    """Check if two DataArrays have the same time axis."""
+    a, b = ensure_time(a), ensure_time(b)
+    if a.sizes["time"] != b.sizes["time"]:
+        return False
+    return np.array_equal(a["time"].values, b["time"].values)
+
+
+def resample_like(
+    data: xr.DataArray, ref: xr.DataArray, fallback_freq=None
+) -> xr.DataArray:
+    """Bin `data` to the bins implied by `ref.time` and label with `ref.time`."""
+    data, ref = ensure_time(data), ensure_time(ref)
+    ref_time = ref["time"].values
+    cal = ref["time"].attrs.get("calendar", "360_day")
+    units = ref["time"].attrs.get("units", "days since 0001-01-01")
+
+    # build edges from ref labels (centre-stamped compatible)
+    t_num = cftime.date2num(ref_time, units, cal)
+
+    MIN_LENGTH = 2
+    if len(t_num) < MIN_LENGTH:
+        msg = "Reference time axis too short to define bins"
+        raise ValueError(msg)
+    mids = 0.5 * (t_num[:-1] + t_num[1:])
+    first_edge = t_num[0] - (mids[0] - t_num[0])
+    last_edge = t_num[-1] + (t_num[-1] - mids[-1])
+    edges = cftime.num2date(
+        np.concatenate([[first_edge], mids, [last_edge]]), units, cal
+    )
+
+    try:
+        out = (
+            data.groupby_bins("time", edges, labels=ref_time, right=False)
+            .mean(skipna=True)
+            .rename({"time_bins": "time"})
+            .assign_coords(time=("time", ref_time))
+        )
+    except Exception:
+        if fallback_freq is None:
+            raise
+        out = data.resample(time=fallback_freq).mean(skipna=True)
+    return out
+
+
+def find_time_dimension(data):
+    """
+    Find the time dimension in the dataset.
+
+    Different climate models use different names for time dimensions
+    """
+    possible_time_dims = ["time", "time_counter", "t", "T", "Time"]
+
+    for dim in data.dims:
+        if dim in possible_time_dims:
+            return dim
+
+    # If no exact match, look for anything with 'time' in the name
+    for dim in data.dims:
+        if "time" in dim.lower():
+            return dim
+
+    return None
+
+
+# def overwrite_time_coordinate(data, ref_data):
+#     """
+#     Overwrite the time coordinate of `data` with that of `ref_data`.
+#     """
+#     time_dim = find_time_dimension(data)
+#     ref_time_dim = find_time_dimension(ref_data)
+#     if time_dim and ref_time_dim:
+#         # Only overwrite if lengths match
+#         if data.sizes[time_dim] == ref_data.sizes[ref_time_dim]:
+#             return data.assign_coords({time_dim: ref_data[ref_time_dim].values})
+#         else:
+#             print(f"✗ Cannot overwrite time: length mismatch ({data.sizes[time_dim]}
+# vs {ref_data.sizes[ref_time_dim]})")
+#     return data
+
+# def align_variables_by_overwriting_time(loaded_vars, ref_var):
+#     """
+#     Overwrites the time coordinate of all variables in loaded_vars with ref_var.
+#     """
+#     ref_data = loaded_vars[ref_var]
+#     aligned_vars = {}
+#     for var, data in loaded_vars.items():
+#         print(data.time.values)
+#         print(ref_data.time.values)
+#         aligned_vars[var] = overwrite_time_coordinate(data, ref_data)
+#     return aligned_vars
+
+# def resample_to_reference_bins(
+#     data, ref_time, calendar, units, time_dim="time_counter", fallback_freq=None
+# ):
+#     """
+#     Resample data to bins defined by ref_time (using cftime logic).
+#     If this fails, fall back to xarray's .resample() with fallback_freq.
+#     """
+#     import cftime
+#     import numpy as np
+#     import xarray as xr
+
+#     try:
+#         numeric = cftime.date2num(ref_time, units, calendar)
+#         if len(numeric) < 2:
+#             raise ValueError("Reference time axis too short for binning.")
+
+#         midpoints = (numeric[:-1] + numeric[1:]) / 2
+#         first_edge = numeric[0] - (midpoints[0] - numeric[0])
+#         last_edge = numeric[-1] + (numeric[-1] - midpoints[-1])
+#         bin_edges_numeric = np.concatenate([[first_edge], midpoints, [last_edge]])
+#         bin_edges = cftime.num2date(bin_edges_numeric, units, calendar)
+
+#         resampled = data.groupby_bins(
+#             time_dim, bin_edges, labels=ref_time, right=False
+#         ).mean()
+#         resampled = resampled.rename({f"{time_dim}_bins": time_dim})
+#         resampled = resampled.assign_coords({time_dim: ref_time})
+#         return resampled
+
+#     except Exception as e:
+#         print(f"[resample_to_reference_bins] Binning failed: {e}")
+#         if fallback_freq is not None:
+#             print(f"[resample_to_reference_bins] Falling back to \
+# .resample({fallback_freq})")
+#             resampled = data.resample({time_dim: fallback_freq}).mean()
+#             return resampled
+#         else:
+#             raise RuntimeError(
+#                 "Resampling to reference bins failed and no fallback_freq provided."
+#             )

--- a/src/spinup_evaluation/xgran/materialise.py
+++ b/src/spinup_evaluation/xgran/materialise.py
@@ -1,0 +1,223 @@
+"""
+A two step process that first resamples and aligns and then outputs data.
+
+This module provides functions to materialize, align, and retrieve resampled artifacts,
+as well as to run metrics using only precomputed data.
+"""
+
+import glob
+import os
+from pathlib import Path
+
+import xarray as xr
+
+from .cache import get_cache_filename, write_metadata
+from .compute import align_all_to_reference, get_data
+from .fix_time import ensure_time, same_time_axis
+
+
+# USED (2): Step 2 of 2. Called by run_metrics_from_materialized
+def open_materialized(var, target_gran, disk_cache_dir="./resampled_cache"):
+    """
+    Open a previously materialized artifact var_*_to_{target_gran}.nc.
+
+    Raises if not found.
+    """
+    pattern = os.path.join(disk_cache_dir, f"{var}_*_to_{target_gran}.nc")
+    hits = sorted(glob.glob(pattern))
+    if not hits:
+        msg = f"No materialized cache for {var}@{target_gran} in {disk_cache_dir}"
+        raise FileNotFoundError(msg)
+    # Use the newest if multiple
+    path = hits[-1]
+    da = xr.open_dataarray(path, chunks={"time": 100})
+    return da
+
+
+# USED (2): Step 1 of 2. Called by two_step_resample_all_aligned
+def materialize_resamples_aligned(
+    variable_file_map: dict,
+    analysis: dict,
+    gran: str,
+    disk_cache_dir: str = "./resampled_cache",
+    prefer_ref_vars: tuple[str, ...] = (
+        "tn",
+        "sshn",
+        "thetao",
+    ),  # tweak to your favorites
+):
+    """
+    Materialize *aligned* artifacts for all variables available at `gran`.
+
+    Every written file will have the exact same time axis.
+    """
+    Path(disk_cache_dir).mkdir(parents=True, exist_ok=True)
+
+    # Variables we plan to materialize at this granularity
+    vars_at_gran = analysis["granularity_to_variables"].get(gran, [])
+    if not vars_at_gran:
+        print(f"[align materialize] No variables at {gran}")
+        return []
+
+    # Choose a reference variable:
+    direct_vars = analysis["direct_from_file_by_granularity"].get(gran, [])
+    ref_var = next((v for v in prefer_ref_vars if v in direct_vars), None)
+    if ref_var is None:
+        ref_var = direct_vars[0] if direct_vars else vars_at_gran[0]
+    print(f"[align materialize] Using '{ref_var}' as reference for {gran}")
+
+    # Load all variables lazily (no write yet)
+    cache = {}
+    loaded = {}
+    for v in vars_at_gran:
+        try:
+            da = get_data(
+                var=v,
+                granularity=gran,
+                variable_file_map=variable_file_map,
+                cache=cache,
+                analysis=analysis,
+                allow_resampling=True,
+                disk_cache_dir=disk_cache_dir,
+                save_to_cache=False,  # don't write yet
+            )
+            loaded[v] = da
+        except FileNotFoundError as e:
+            print(f"[align materialize] skip {v}@{gran}: {e}")
+
+    if ref_var not in loaded:
+        print(
+            f"[align materialize] Reference '{ref_var}'"
+            f"failed to load; aborting for {gran}"
+        )
+        return []
+
+    # Align everyone to the reference axis (uses your resample_to_reference_bins under
+    # the hood)
+    aligned = align_all_to_reference(loaded, ref_var=ref_var, fallback_freq=gran)
+
+    # Persist aligned results into the cache
+    written = []
+    ref = ensure_time(aligned[ref_var])
+    # ref_time = ref["time"].values
+    cal = ref["time"].attrs.get("calendar", "360_day")
+    units = ref["time"].attrs.get("units", "days since 0001-01-01")
+
+    for v, da in aligned.items():
+        da_checked = ensure_time(da)
+        # sanity: enforce equality
+        if not same_time_axis(da_checked, ref):
+            print(f"[align materialize] {v}@{gran} still misaligned; skipping write")
+            continue
+
+        cache_file = get_cache_filename(v, "aligned", gran, cache_dir=disk_cache_dir)
+        da_checked.to_netcdf(cache_file)
+
+        meta = {
+            "variable": v,
+            "source_granularity": "aligned",
+            "target_granularity": gran,
+            "calendar": cal,
+            "units": units,
+            "reference_variable": ref_var,
+            "time_len": int(da_checked.sizes["time"]),
+            "note": "Aligned to reference axis during materialization",
+        }
+        write_metadata(cache_file, meta)
+        written.append(cache_file)
+        print(f"[align materialize] wrote {os.path.basename(cache_file)}")
+
+    return written
+
+
+# USED (2) : Step 2 of 2. Called by two_step_metrics_all
+def run_metrics_from_materialized(
+    metric_requirements,
+    metric_functions,
+    target_gran,
+    disk_cache_dir="./resampled_cache",
+):
+    """
+    Step 2: Compute metrics using only materialized data.
+
+    No on-the-fly resampling is allowed.
+    """
+    results = {}
+
+    for metric_name, required_vars in metric_requirements.items():
+        if metric_name not in metric_functions:
+            continue
+
+        try:
+            # Load all inputs from materialized artifacts
+            inputs = [
+                open_materialized(v, target_gran, disk_cache_dir) for v in required_vars
+            ]
+
+            # Align on time (inner join) before computing
+            aligned = xr.align(*inputs, join="inner")
+
+            out = metric_functions[metric_name](*aligned)
+            results[(target_gran, metric_name)] = {
+                "result": out,
+                "granularity": target_gran,
+                "variables_used": required_vars,
+            }
+            print(f"✓ {metric_name}@{target_gran}")
+        except FileNotFoundError as e:
+            print(f"✗ {metric_name}@{target_gran}: {e}")
+
+    return results
+
+
+# USED (2): Step 1 of 2.
+def two_step_resample_all_aligned(
+    variable_file_map,
+    analysis,
+    targets=None,
+    disk_cache_dir="./resampled_cache",
+):
+    """Materialize aligned artifacts for all variables at the specified granularity."""
+    if targets is None:
+        targets = analysis["available_granularities"]
+    for gran in targets:
+        print(f"\n[Two-step aligned] Materializing aligned artifacts at {gran}")
+        materialize_resamples_aligned(
+            variable_file_map=variable_file_map,
+            analysis=analysis,
+            gran=gran,
+            disk_cache_dir=disk_cache_dir,
+        )
+
+
+# USED (2): Step 2 of 2.
+def two_step_metrics_all(
+    metric_requirements,
+    metric_functions,
+    targets,
+    disk_cache_dir="./resampled_cache",
+):
+    """Run metrics for each granularity exclusively from materialized artifacts."""
+    all_results = {}
+    for gran in targets:
+        print(f"\n[Two-step] Metrics at {gran}")
+        res = run_metrics_from_materialized(
+            metric_requirements=metric_requirements,
+            metric_functions=metric_functions,
+            target_gran=gran,
+            disk_cache_dir=disk_cache_dir,
+        )
+        all_results.update(res)
+
+    # We currently get data in this shape
+    # ('10d', 'check_density') -> {result, granularity, variables_used}
+    # we want
+    # ['10d'] -> { 'check_density': result, 'temperature_500m_30NS_metric : result, ...}
+
+    results_by_granularity = {}
+    for (gran, func), result_meta in all_results.items():
+        if gran not in results_by_granularity:
+            results_by_granularity[gran] = {}
+        results_by_granularity[gran][func] = result_meta["result"]
+
+    return results_by_granularity


### PR DESCRIPTION
This is a first attempt at bringing the [granularity](https://github.com/ma595/granularity) resampling to the evaluation project. We copy `xgran` in a vendored sense into spinup-evaluation. In future it could be packaged separately and introduced as a dependency depending on whether there is interest. 

## The problem
A common use case is illustrated in #54. 

We need to compute metrics as defined in `metrics.py` at different temporal resolutions. Based on the arguments (temperature, ssh, velocity, salinity, UNUSED(salinity)) to these metric functions (`temperature_500m_30NS_metric`, `temperature_BWbox_metric`, `temperature_DWbox_metric`, `ACC_Drake_metric_2`) we can determine an intelligent resampling strategy to allow us to compute metrics even when variables at a certain temporal granularity is not available to us. We can only do downsamping by averaging from finer temporal granularity to coarser (up sampling is not allowed). 
When averaging we use the finest available data (this needs to be tested). 

## Features of xgran
- Analysis deduces what variables/files we have and what metrics we can calculate. It stores this information in a dictionary (`analysis`) that can be passed around. 
- The `compute.py` file implements a single pass resampling. 
  - `get_data` is the core function that resamples data. 
  - We must temporally align all data to some well known NEMO reference at that granularity, otherwise operations between metrics having differing temporal binning at a given granularity will fail - this is explained in #59. 
    - Currently this is a two step process. We resample and then align all files separately given a reference. This works, but it could be compressed to a single pass. Everything is done lazily so this doesn't really have much of a performance hit. 
- The `materialize.py` approach forces this to behave in a two step process.


## Resampling
Nemo files are center stamped. Whereas xarray resample at edges. See issue #59. 

## TODO
- [ ] Wire in with the rest of spinup-evaluation using a thin layer
- [ ] Tests how resampling assumptions affect the outputs of the metrics. Do results change? Write test. 
- [ ] Does the specification of the variable in the input file work? This is the current approach in spinup-evaluation. 
- [ ] Overwriting aligned_resampled data leads to error.

Closes #54, #59