### PR TITLE
Add lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ nemo-spinup-evaluation --sim-path <simulation_dir> --ref-sim-path <reference_dir
 | `--results-dir`        | Directory to save output CSVs                                 | `results`                 | No       |
 | `--result-file-prefix` | Prefix for output files                                       | `metrics_results`         | No       |
 | `--mode`               | Which metric suite(s) to run: `output`, `restart`, or `both`  | `both`                    | No       |
+| `--eager`              | Load data eagerly (numpy) instead of lazily (dask)            | `false`                   | No       |
 
 
 ## Tests

--- a/docs/source/Command-Line-Interface.md
+++ b/docs/source/Command-Line-Interface.md
@@ -10,6 +10,7 @@ nemo-spinup-evaluation \
   [--mode output|restart|both]           # Which metric suite(s) to run (default: both)
   [--results-dir results]                # Output directory (default shown)
   [--result-file-prefix metrics_results] # Output file prefix (default shown)
+  [--eager]                              # Load data eagerly with numpy (default: off)
 ```
 
 **Arguments:**
@@ -19,5 +20,6 @@ nemo-spinup-evaluation \
 - `--mode`: Which metric suite(s) to run: `output`, `restart`, or `both` (default: `both`).
 - `--results-dir`: Directory to save output CSVs (default: `results`).
 - `--result-file-prefix`: Prefix for output files (default: `metrics_results`).
+- `--eager`: Load data eagerly using numpy instead of lazily with dask. Faster for small files.
 
 At least one of `--sim-path` or `--ref-sim-path` must be supplied. Providing only `--sim-path` runs the metrics on that simulation in isolation; providing both runs a diff between the two.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "xarray[io]>=2024.7.0",
     "numpy>=2.0.0",
-    "dask[array]",
+    "dask[array]>=2024.7.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "xarray[io]>=2024.7.0",
     "numpy>=2.0.0",
+    "dask[array]",
 ]
 
 [project.optional-dependencies]

--- a/src/nemo_spinup_evaluation/cli.py
+++ b/src/nemo_spinup_evaluation/cli.py
@@ -243,8 +243,8 @@ def _compute_means(
     abs_err = abs(delta)
 
     # Summary scalars
-    mae = float(abs_err.mean(skipna=True).values.item())
-    rmse = float((delta**2).mean(skipna=True).values.item() ** 0.5)
+    mae = float(abs_err.mean(skipna=True).values)
+    rmse = float((delta**2).mean(skipna=True).values) ** 0.5
 
     return delta, abs_err, mae, rmse
 
@@ -281,7 +281,7 @@ def compute_diffs_and_stats(
             continue
 
         try:
-            delta, abs_err, mae, rmse = _compute_means(val, ref_val)
+            delta, _abs_err, mae, rmse = _compute_means(val, ref_val)
 
             # keep names helpful
             delta = delta.rename(f"diff_{key}")

--- a/src/nemo_spinup_evaluation/cli.py
+++ b/src/nemo_spinup_evaluation/cli.py
@@ -90,6 +90,13 @@ def parse_args(argv) -> argparse.Namespace:
         default="metrics_results",
         help="Prefix to use for the result files.",
     )
+    parser.add_argument(
+        "--eager",
+        action="store_true",
+        default=False,
+        help="Load data eagerly (numpy) instead of lazily (dask). "
+        "Faster for small files.",
+    )
     args = parser.parse_args(argv)
 
     if not args.sim_path and not args.ref_sim_path:
@@ -342,12 +349,15 @@ def main(argv=None) -> int:
     prefix: str = args.result_file_prefix
 
     # Load primary and (optional) reference datasets
-    data = load_dino_data(args.mode, args.sim_path, dino_setup, do_standardise=True)
+    lazy = not args.eager
+    data = load_dino_data(
+        args.mode, args.sim_path, dino_setup, do_standardise=True, lazy=lazy
+    )
 
     data_ref = None
     if args.ref_sim_path:
         data_ref = load_dino_data(
-            args.mode, args.ref_sim_path, dino_setup, do_standardise=True
+            args.mode, args.ref_sim_path, dino_setup, do_standardise=True, lazy=lazy
         )
 
     # Extract paths with proper type cast

--- a/src/nemo_spinup_evaluation/loader.py
+++ b/src/nemo_spinup_evaluation/loader.py
@@ -19,7 +19,7 @@ def _open_cached(cache: Dict[str, xr.Dataset], base: str, relpath: str) -> xr.Da
         if not os.path.exists(full):
             msg = f"File not found: {full}"
             raise FileNotFoundError(msg)
-        cache[relpath] = xr.open_dataset(full)
+        cache[relpath] = xr.open_dataset(full, chunks={})
     return cache[relpath]
 
 
@@ -200,7 +200,7 @@ def load_mesh_mask(path: Path) -> xr.Dataset:
     if not path.exists():
         msg = f"Mesh mask file not found: {path}"
         raise FileNotFoundError(msg)
-    ds = xr.open_dataset(path)
+    ds = xr.open_dataset(path, chunks={})
     required_vars = ["tmask", "e1t", "e2t", "e3t_0"]
     missing = [v for v in required_vars if v not in ds.variables]
     if missing:
@@ -340,7 +340,7 @@ def load_dino_data(
             raise FileNotFoundError(msg)
         else:
             paths["restart"] = restart_path
-            data["restart"] = xr.open_dataset(restart_path)
+            data["restart"] = xr.open_dataset(restart_path, chunks={})
 
     # outputs (optional / controlled by mode)
     data["grid"] = {}
@@ -352,7 +352,7 @@ def load_dino_data(
         if restart_path is None:
             msg = "No restart file found matching pattern."
             raise FileNotFoundError(msg)
-        data["restart"] = xr.open_dataset(restart_path)
+        data["restart"] = xr.open_dataset(restart_path, chunks={})
         vars_map = load_grid_variables(base, var_specs, files_cache)
         data["grid"].update(vars_map)
 

--- a/src/nemo_spinup_evaluation/loader.py
+++ b/src/nemo_spinup_evaluation/loader.py
@@ -12,14 +12,17 @@ from nemo_spinup_evaluation.standardise_inputs import VARIABLE_ALIASES, standard
 VarSpec = Mapping[str, Union[str, Mapping[str, str]]]
 
 
-def _open_cached(cache: Dict[str, xr.Dataset], base: str, relpath: str) -> xr.Dataset:
+def _open_cached(
+    cache: Dict[str, xr.Dataset], base: str, relpath: str, lazy: bool = True
+) -> xr.Dataset:
     """Open a dataset once, caching by relative path."""
     if relpath not in cache:
         full = os.path.join(base, relpath)
         if not os.path.exists(full):
             msg = f"File not found: {full}"
             raise FileNotFoundError(msg)
-        cache[relpath] = xr.open_dataset(full, chunks={})
+        open_kw = {"chunks": {}} if lazy else {}
+        cache[relpath] = xr.open_dataset(full, **open_kw)
     return cache[relpath]
 
 
@@ -56,7 +59,7 @@ def _infer_var_name(ds: xr.Dataset, canon: str) -> str:
 
 
 def _normalise_var_specs(
-    var_specs: VarSpec, file_cache: Dict[str, xr.Dataset], base: str
+    var_specs: VarSpec, file_cache: Dict[str, xr.Dataset], base: str, lazy: bool = True
 ) -> Dict[str, Dict[str, str]]:
     """
     Normalise variable specifications in yaml file.
@@ -79,6 +82,8 @@ def _normalise_var_specs(
         A cache of opened xarray datasets, keyed by file path.
     base : str
         The base directory for resolving relative file paths.
+    lazy : bool
+        Whether to use dask-backed lazy loading.
 
     Returns
     -------
@@ -89,7 +94,7 @@ def _normalise_var_specs(
     for canon, spec in var_specs.items():
         if isinstance(spec, str):
             # simple form → infer variable name
-            ds = _open_cached(file_cache, base, spec)
+            ds = _open_cached(file_cache, base, spec, lazy=lazy)
             var_name = _infer_var_name(ds, canon)
             normalised[canon] = {"file": spec, "var": var_name}
 
@@ -101,7 +106,7 @@ def _normalise_var_specs(
                 msg = f"Missing 'file' for variable '{canon}'."
                 raise ValueError(msg)
             fname = str(spec["file"])
-            ds = _open_cached(file_cache, base, fname)
+            ds = _open_cached(file_cache, base, fname, lazy=lazy)
 
             if "var" in spec:
                 var_name = str(spec["var"])  # user-specified → trust it
@@ -195,12 +200,13 @@ def resolve_mesh_mask(mesh_mask: str, sim_path: str) -> Path:
     return candidate
 
 
-def load_mesh_mask(path: Path) -> xr.Dataset:
+def load_mesh_mask(path: Path, lazy: bool = True) -> xr.Dataset:
     """Load the NEMO mesh mask file and validate required fields."""
     if not path.exists():
         msg = f"Mesh mask file not found: {path}"
         raise FileNotFoundError(msg)
-    ds = xr.open_dataset(path, chunks={})
+    open_kw = {"chunks": {}} if lazy else {}
+    ds = xr.open_dataset(path, **open_kw)
     required_vars = ["tmask", "e1t", "e2t", "e3t_0"]
     missing = [v for v in required_vars if v not in ds.variables]
     if missing:
@@ -238,7 +244,10 @@ def get_restart_file_path(base: str, restart_hint: Optional[str]) -> Optional[st
 
 
 def load_grid_variables(
-    base: str, output_specs: VarSpec, files_cache: Dict[str, xr.Dataset]
+    base: str,
+    output_specs: VarSpec,
+    files_cache: Dict[str, xr.Dataset],
+    lazy: bool = True,
 ) -> Dict[str, xr.DataArray]:
     """
     Build a dict of {canonical_name: DataArray} with a single open per file.
@@ -253,18 +262,20 @@ def load_grid_variables(
         The variable specifications for the output data.
     files_cache : Dict[str, xr.Dataset]
         A cache of opened xarray datasets, keyed by file path.
+    lazy : bool
+        Whether to use dask-backed lazy loading.
 
     Returns
     -------
     Dict[str, xr.DataArray]
         A dictionary mapping canonical variable names to their DataArray objects.
     """
-    norm = _normalise_var_specs(output_specs, files_cache, base)
+    norm = _normalise_var_specs(output_specs, files_cache, base, lazy=lazy)
 
     # Pull the arrays
     out: Dict[str, xr.DataArray] = {}
     for canon, spec in norm.items():
-        ds = _open_cached(files_cache, base, spec["file"])
+        ds = _open_cached(files_cache, base, spec["file"], lazy=lazy)
         out[canon] = ds[spec["var"]]
 
     return out
@@ -275,6 +286,7 @@ def load_dino_data(
     base: str,
     setup: Mapping[str, object],
     do_standardise: bool = True,
+    lazy: bool = True,
 ) -> Dict[str, object]:
     """
     Load DINO data according to YAML setup.
@@ -289,6 +301,8 @@ def load_dino_data(
        A mapping containing the YAML configuration for data loading.
     do_standardise : bool
        Whether to standardise variable names using aliases.
+    lazy : bool
+       Whether to use dask-backed lazy loading.
 
     Returns
     -------
@@ -307,6 +321,7 @@ def load_dino_data(
         msg = "Mode must be one of 'output', 'restart', 'both'"
         raise ValueError(msg)
 
+    open_kw = {"chunks": {}} if lazy else {}
     base = os.path.abspath(base)
 
     data: Dict[str, object] = {}
@@ -328,7 +343,7 @@ def load_dino_data(
     # Resolve mesh mask path
     mesh_mask_path = resolve_mesh_mask(str(setup["mesh_mask"]), base)
     paths["mesh_mask"] = str(mesh_mask_path)
-    data["mesh_mask"] = load_mesh_mask(mesh_mask_path)
+    data["mesh_mask"] = load_mesh_mask(mesh_mask_path, lazy=lazy)
 
     # restart (optional / controlled by mode)
     data["restart"] = None
@@ -340,7 +355,7 @@ def load_dino_data(
             raise FileNotFoundError(msg)
         else:
             paths["restart"] = restart_path
-            data["restart"] = xr.open_dataset(restart_path, chunks={})
+            data["restart"] = xr.open_dataset(restart_path, **open_kw)
 
     # outputs (optional / controlled by mode)
     data["grid"] = {}
@@ -352,8 +367,8 @@ def load_dino_data(
         if restart_path is None:
             msg = "No restart file found matching pattern."
             raise FileNotFoundError(msg)
-        data["restart"] = xr.open_dataset(restart_path, chunks={})
-        vars_map = load_grid_variables(base, var_specs, files_cache)
+        data["restart"] = xr.open_dataset(restart_path, **open_kw)
+        vars_map = load_grid_variables(base, var_specs, files_cache, lazy=lazy)
         data["grid"].update(vars_map)
 
         # Store the full paths to output files

--- a/src/nemo_spinup_evaluation/metrics_io.py
+++ b/src/nemo_spinup_evaluation/metrics_io.py
@@ -28,7 +28,7 @@ def _build_timeseries_dataframe(results: Mapping[str, Any]) -> pd.DataFrame:
                 timestamp = [str(t) for t in v["time_counter"].values]
             ts_cols[k] = v.values
         elif isinstance(v, xr.DataArray) and v.ndim == 0:
-            ts_cols[k] = [v.item()]
+            ts_cols[k] = [float(v)]
         elif not k.endswith(("_mae", "_rmse")):
             ts_cols[k] = [v]
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -92,6 +92,7 @@ def test_integration_with_real_data(real_input_dir, output_file_path, run):
         "both",
         "--results-dir",
         str(output_file_path),
+        "--eager",
     ]
 
     if run == "with_ref":

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -92,8 +92,10 @@ def test_integration_with_real_data(real_input_dir, output_file_path, run):
         "both",
         "--results-dir",
         str(output_file_path),
-        "--eager",
     ]
+
+    if run != "no_ref":
+        args.append("--eager")
 
     if run == "with_ref":
         args += ["--ref-sim-path", "tests/data/DINO_subsampled_B"]


### PR DESCRIPTION
Introduces lazy loading with dask 

Fixes #128 

Tested this on my Arcus VM with 6GB of memory and the `restart3` example runs end to end with no changes to output. 

- Introduces --eager flag to circumvent dask lazy loading
- Modified pre-existing test to run in lazy mode
- 2/3 tests now run in `--eager` fashion as they are a lot slower otherwise test runs in lazy mode.

