### PR TITLE
Move test data to zenodo

### DIFF
--- a/tests/get-data.sh
+++ b/tests/get-data.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
-curl -O https://thredds-su.ipsl.fr/thredds/fileServer/NEMO-SPINUP/evaluation/test-data/subsampled/DINO-simple-small.tar.gz
-echo "Extracting test data to tests/data"
-tar -xzf DINO-simple-small.tar.gz -C tests/data
-rm DINO-simple-small.tar.gz
+set -e
+
+DATA_DIR="tests/data"
+ZIP_FILE="evaluation-test.zip"
+CONCEPT_ID="19474413"
+
+# Resolve the concept ID to the latest version
+LATEST=$(curl -sI "https://zenodo.org/records/${CONCEPT_ID}" | grep -i "^location:" | tr -d '\r' | awk -F/ '{print $NF}')
+ZENODO_URL="https://zenodo.org/records/${LATEST}/files/${ZIP_FILE}"
+
+echo $LATEST
+
+mkdir -p "${DATA_DIR}"
+curl -L -o "${ZIP_FILE}" "${ZENODO_URL}"
+unzip -o "${ZIP_FILE}" -d "${DATA_DIR}"
+# rm "${ZIP_FILE}"

--- a/tests/get-data.sh
+++ b/tests/get-data.sh
@@ -14,4 +14,4 @@ echo $LATEST
 mkdir -p "${DATA_DIR}"
 curl -L -o "${ZIP_FILE}" "${ZENODO_URL}"
 unzip -o "${ZIP_FILE}" -d "${DATA_DIR}"
-# rm "${ZIP_FILE}"
+rm "${ZIP_FILE}"

--- a/tests/get-data.sh
+++ b/tests/get-data.sh
@@ -3,13 +3,7 @@ set -e
 
 DATA_DIR="tests/data"
 ZIP_FILE="evaluation-test.zip"
-CONCEPT_ID="19474413"
-
-# Resolve the concept ID to the latest version
-LATEST=$(curl -sI "https://zenodo.org/records/${CONCEPT_ID}" | grep -i "^location:" | tr -d '\r' | awk -F/ '{print $NF}')
-ZENODO_URL="https://zenodo.org/records/${LATEST}/files/${ZIP_FILE}"
-
-echo $LATEST
+ZENODO_URL="https://zenodo.org/records/19557419/files/${ZIP_FILE}"
 
 mkdir -p "${DATA_DIR}"
 curl -L -o "${ZIP_FILE}" "${ZENODO_URL}"


### PR DESCRIPTION
Update test data location to [zenodo](https://zenodo.org/records/19557419) instead of spirit. Longer term this is more sustainable. 

TODO:
- [x] Revert to direct record links instead of zenodo concept ID. 

Closes #134 