### PR TITLE
Simplify restart file load

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ variable_map:
 ```yaml
 mesh_mask: mesh_mask.nc
 
-restart_files: 'restart'
+restart: restart.nc
 
 output_variables:
   temperature:

--- a/configs/DINO-setup.yaml
+++ b/configs/DINO-setup.yaml
@@ -2,7 +2,7 @@
 
 mesh_mask: mesh_mask.nc
 
-restart_files: 'restart'
+restart: DINO_00576000_restart.nc
 
 output_variables:
   temperature:

--- a/docs/source/Model-Configuration.md
+++ b/docs/source/Model-Configuration.md
@@ -40,7 +40,7 @@ variable_map:
 ```yaml
 mesh_mask: mesh_mask.nc
 
-restart_files: 'restart'
+restart: restart.nc
 
 output_variables:
   temperature:

--- a/src/nemo_spinup_evaluation/loader.py
+++ b/src/nemo_spinup_evaluation/loader.py
@@ -1,9 +1,8 @@
 """Functions to load NEMO model output and restart files based on YAML configuration."""
 
-import glob
 import os
 from pathlib import Path
-from typing import Dict, Mapping, Optional, cast
+from typing import Dict, Mapping, cast
 
 import xarray as xr
 
@@ -87,16 +86,16 @@ def _check_grid_time_alignment(grid_data: Mapping[str, xr.DataArray | xr.Dataset
             raise ValueError(msg)
 
 
-def resolve_mesh_mask(mesh_mask: str, sim_path: str) -> Path:
-    """Resolve the mesh mask path, handling absolute and relative paths."""
-    p = Path(mesh_mask)
-    candidate = p if p.is_absolute() else Path(sim_path) / mesh_mask
-    if not candidate.exists():
+def resolve_file_path(file_name: str, sim_path: str) -> Path:
+    """Resolve a file path, handling absolute and relative paths."""
+    p = Path(file_name)
+    candidate = p if p.is_absolute() else Path(sim_path) / file_name
+    if not candidate.is_file():
         hint = (
-            "Set `mesh_mask` to an absolute path in your YAML, "
-            "or ensure it exists under --sim-path."
+            "Ensure `mesh_mask` and `restart` exist under --sim-path, "
+            "or use absolute paths in your YAML."
         )
-        msg = f"Mesh mask file not found: {candidate}. {hint}"
+        msg = f"File not found: {candidate}. {hint}"
         raise FileNotFoundError(msg)
 
     return candidate
@@ -114,34 +113,6 @@ def load_mesh_mask(path: Path) -> xr.Dataset:
         msg = f"Mesh mask file {path} is missing required variables: {missing}"
         raise ValueError(msg)
     return ds
-
-
-def get_restart_file_path(base: str, restart_hint: Optional[str]) -> Optional[str]:
-    """
-    Get the restart file path based on base directory and hint.
-
-    If restart_hint ends with '.nc', it is treated as a direct file name.
-    Otherwise, we search for files matching '*{hint}*.nc' in the base directory.
-
-    Parameters
-    ----------
-    base : str
-        The base directory to search for restart files.
-    restart_hint : Optional[str]
-        An optional hint for the restart file name (e.g., 'restart').
-
-    Returns
-    -------
-    Optional[str]
-        The path to the restart file if found, otherwise None.
-    """
-    if restart_hint and restart_hint.endswith(".nc"):
-        candidate = os.path.join(base, restart_hint)
-        return candidate if os.path.exists(candidate) else None
-
-    pattern_core = restart_hint if restart_hint else "restart"
-    matches = sorted(glob.glob(os.path.join(base, f"*{pattern_core}*.nc")))
-    return matches[0] if matches else None
 
 
 def load_grid_variables(
@@ -274,22 +245,18 @@ def load_dino_data(
         raise ValueError(msg)
 
     # Resolve mesh mask path
-    mesh_mask_path = resolve_mesh_mask(str(setup["mesh_mask"]), base)
+    mesh_mask_path = resolve_file_path(str(setup["mesh_mask"]), base)
     paths["mesh_mask"] = str(mesh_mask_path)
     data["mesh_mask"] = load_mesh_mask(mesh_mask_path)
 
     # restart (optional / controlled by mode)
     data["restart"] = None
-    restart_hint = str(setup.get("restart_files") or "")
+    restart_file = str(setup.get("restart") or "")
 
     if mode in ("restart", "both"):
-        restart_path = get_restart_file_path(base, restart_hint)
-        if restart_path is None:
-            msg = "No restart file found matching pattern."
-            raise FileNotFoundError(msg)
-        else:
-            paths["restart"] = restart_path
-            data["restart"] = xr.open_dataset(restart_path)
+        restart_path = resolve_file_path(restart_file, base)
+        paths["restart"] = restart_path
+        data["restart"] = xr.open_dataset(restart_path)
 
     # outputs (optional / controlled by mode)
     data["grid"] = {}
@@ -306,11 +273,11 @@ def load_dino_data(
         # Check grid variables for temporal alignment
         _check_grid_time_alignment(data["grid"])
 
-        restart_path = get_restart_file_path(base, restart_hint)
-        if restart_path is None:
-            msg = "No restart file found matching pattern."
-            raise FileNotFoundError(msg)
-        data["restart"] = xr.open_dataset(restart_path)
+        # Restart file is optional in output mode
+        if mode == "output" and restart_file:
+            restart_path = resolve_file_path(restart_file, base)
+            paths["restart"] = restart_path
+            data["restart"] = xr.open_dataset(restart_path)
 
     # expose the file cache
     data["files"] = files_cache

--- a/src/nemo_spinup_evaluation/loader.py
+++ b/src/nemo_spinup_evaluation/loader.py
@@ -239,7 +239,7 @@ def load_dino_data(
         "output_files": [],
     }
 
-    # mesh mask (required)
+    # 1. Mesh mask (required)
     if "mesh_mask" not in setup:
         msg = "setup must specify 'mesh_mask'."
         raise ValueError(msg)
@@ -249,16 +249,18 @@ def load_dino_data(
     paths["mesh_mask"] = str(mesh_mask_path)
     data["mesh_mask"] = load_mesh_mask(mesh_mask_path)
 
-    # restart (optional / controlled by mode)
+    # 2. Restart file (optional in output mode)
     data["restart"] = None
     restart_file = str(setup.get("restart") or "")
 
-    if mode in ("restart", "both"):
+    # Restart file is required in modes, restart and both
+    # Only attempt load in output mode if restart is present in config
+    if mode in ("restart", "both") or (mode == "output" and restart_file):
         restart_path = resolve_file_path(restart_file, base)
         paths["restart"] = restart_path
         data["restart"] = xr.open_dataset(restart_path)
 
-    # outputs (optional / controlled by mode)
+    # 3. Output files (optional in restart mode)
     data["grid"] = {}
     if mode in ("output", "both"):
         if "output_variables" not in setup:
@@ -273,17 +275,11 @@ def load_dino_data(
         # Check grid variables for temporal alignment
         _check_grid_time_alignment(data["grid"])
 
-        # Restart file is optional in output mode
-        if mode == "output" and restart_file:
-            restart_path = resolve_file_path(restart_file, base)
-            paths["restart"] = restart_path
-            data["restart"] = xr.open_dataset(restart_path)
-
     # expose the file cache
     data["files"] = files_cache
     data["paths"] = paths
 
-    # standardise names after loading has taken place
+    # 4. Standardise names after loading has taken place
     if "variable_map" in setup:
         var_map = cast(VarMap, setup["variable_map"])
 
@@ -299,7 +295,7 @@ def load_dino_data(
             name: standardise_vars(da, var_map) for name, da in data["grid"].items()
         }
 
-    # Check for expected coordinates after all other processing
+    # 5. Check for expected coordinates after all other processing
     required_coords = ("time_counter", "depth", "nav_lat", "nav_lon")
     _check_required_coords(data["mesh_mask"], required_coords, "mesh mask")
 

--- a/tests/DINO-test-setup.yaml
+++ b/tests/DINO-test-setup.yaml
@@ -3,7 +3,7 @@
 
 mesh_mask: mesh_mask.nc
 
-restart_files: 'restart'
+restart: restart.nc
 
 output_variables:
   temperature:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -87,6 +87,20 @@ def test_load_dino_data_missing_restart_file(test_data_path, mode):
         load_dino_data(mode, test_data_path, bad_setup)
 
 
+def test_load_dino_data_no_restart_output_mode(test_data_path):
+    """Test that restart file is optional in output mode."""
+
+    # Setup with no restart entry
+    setup = {
+        "mesh_mask": "mesh_mask.nc",
+        "output_variables": {"temperature": {"file": "grid_T_3D.nc", "var": "toce"}},
+        "variable_map": {"depth": ["nav_lev"]},
+    }
+
+    data = load_dino_data("output", test_data_path, setup)
+    assert data["restart"] is None
+
+
 @pytest.mark.parametrize("mode", ["output", "both"])
 def test_load_dino_data_missing_output_file(test_data_path, mode):
     """Test error handling when output file is missing."""

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -55,16 +55,16 @@ def test_load_dino_data_missing_mesh_mask(test_data_path, mode):
     # Setup with missing mesh_mask file
     bad_setup = {
         "mesh_mask": "missing_mesh_mask.nc",
-        "restart_files": "restart.nc",
+        "restart": "restart.nc",
         "output_variables": {"temperature": "grid_T_3D.nc"},
     }
 
-    with pytest.raises(FileNotFoundError, match=r"Mesh mask"):
+    with pytest.raises(FileNotFoundError, match=r"mesh_mask"):
         load_dino_data(mode, test_data_path, bad_setup)
 
     # Setup without mesh_mask
     bad_setup = {
-        "restart_files": "restart",
+        "restart": "restart.nc",
         "output_variables": {"temperature": "grid_T_3D.nc"},
     }
 
@@ -79,11 +79,11 @@ def test_load_dino_data_missing_restart_file(test_data_path, mode):
     # Setup with non-existent restart file
     bad_setup = {
         "mesh_mask": "mesh_mask.nc",
-        "restart_files": "missing_restart",
+        "restart": "missing_restart.nc",
         "output_variables": {"temperature": {"file": "grid_T_3D.nc", "var": "toce"}},
     }
 
-    with pytest.raises(FileNotFoundError, match=r"restart file"):
+    with pytest.raises(FileNotFoundError, match=r"restart"):
         load_dino_data(mode, test_data_path, bad_setup)
 
 
@@ -94,7 +94,7 @@ def test_load_dino_data_missing_output_file(test_data_path, mode):
     # Setup with non-existent output file
     bad_setup = {
         "mesh_mask": "mesh_mask.nc",
-        "restart_files": "restart",
+        "restart": "restart.nc",
         "output_variables": {"temperature": {"file": "missing.nc", "var": "toce"}},
     }
 


### PR DESCRIPTION
Rename config `restart_files` to `restart` and remove globbing behaviour. A proper filename must now be given in the YAML config file.

Consolidate restart file loading and ensure file is optional in `output` mode.